### PR TITLE
Fix golang build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,4 @@
 ARG BASE_IMAGE
-ARG BUILD_IMAGE
-
-# build container
-FROM ${BUILD_IMAGE:-golang:latest} AS builder
-WORKDIR /go/src/github.com/racktopsystems/brickstor-csi-driver/
-COPY . ./
-ARG VERSION
-ENV VERSION=${VERSION:-0.0.0}
-ARG TARGETOS TARGETARCH
-ARG DRIVER_BIN=brickstor-csi-driver_${TARGETOS}_${TARGETARCH}
-RUN go version
-RUN make build
-RUN cp bin/${DRIVER_BIN} /brickstor-csi-driver
 
 # driver container
 FROM ${BASE_IMAGE:-alpine:latest}
@@ -24,7 +11,10 @@ RUN apk add --no-cache rpcbind nfs-utils cifs-utils ca-certificates
 RUN apk update && apk add "libcrypto3>=3.0.8-r3" "libssl3>=3.0.8-r3" && rm -rf /var/cache/apt/*
 # create driver config folder and print version
 RUN mkdir -p /config/
-COPY --from=builder /brickstor-csi-driver /
+# copy driver binary matching image architecture
+ARG BIN_DIR VERSION TARGETOS TARGETARCH
+ARG DRIVER_BIN=brickstor-csi-driver_${TARGETOS}_${TARGETARCH}_v${VERSION}
+COPY ${BIN_DIR}/${DRIVER_BIN} /brickstor-csi-driver
 RUN /brickstor-csi-driver --version
 # init script: runs rpcbind before starting the plugin
 RUN echo $'#!/usr/bin/env sh\nupdate-ca-certificates\nrpcbind;\n/brickstor-csi-driver "$@";\n' > /init.sh

--- a/README.md
+++ b/README.md
@@ -415,6 +415,9 @@ make
 
 # build go app on local machine
 make build
+
+# build go app inside Docker container using an official golang image
+make docker-build VERSION=1.0.1
 ```
 
 ### Run
@@ -477,24 +480,33 @@ go test tests/e2e/driver_test.go -v -count 1 \
 All development happens in the `main` branch,
 when it's time to publish a new version, a new git tag should be created.
 
-1. Build and test the new version using local registry:
-   ```bash
-   # build development version:
-   make container-build
-   # publish to local registry
-   make container-build PUSH=1 REGISTRY=192.168.1.1:5000
-   # test plugin using local registry
-   TEST_K8S_IP=10.3.199.250 make test-all-local-image-container
-   ```
+Build and test the new version using local registry:
+```bash
+# build a development version:
+make container-build
+# publish to local registry
+make container-build PUSH=1 REGISTRY=192.168.1.1:5000
+# test plugin using local registry
+TEST_K8S_IP=10.3.199.250 make test-all-local-image-container
+```
 
-2. To release a new version run command:
-   ```bash
-   make release VERSION=X.X.X LATEST=1
-   ```
-   This script does following:
-   - builds driver container 'brickstor-csi-driver'
-   - Login to hub.docker.com will be requested
-   - publishes driver version 'racktopsystems/brickstor-csi-driver:X.X.X' to hub.docker.com
-   - creates new Git tag 'vX.X.X' and pushes to the repository.
+### Release
 
-3. Update Github [releases](https://github.com/racktopsystems/brickstor-csi-driver/releases).
+`Makefile` provides a release script which does the following
+  - Creates new git tag 'vX.X.X' and pushes to the repository
+  - Requests login to hub.docker.com
+  - Builds Docker image 'brickstor-csi-driver'
+  - Publishes driver version 'racktopsystems/brickstor-csi-driver:X.X.X' to hub.docker.com
+   
+To release a new version
+
+1. [Build](#build) the driver binaries.
+2. Run the release script:
+    ```bash
+    # VERSION=X.X.X is the version to be released. Also tags Docker image using this version.
+
+    # LATEST=1 will tag resulting Docker image as latest (default is not).
+
+    make release VERSION=X.X.X LATEST=1
+    ```
+2. Update Github [releases](https://github.com/racktopsystems/brickstor-csi-driver/releases).


### PR DESCRIPTION
Building multi-arch driver bins using Docker buildx on macos fails due to known stability issues around golang and QEMU.

```
#24 [linux/amd64 builder 5/6] RUN make build
#24 9.911 internal/testlog
#24 9.911 internal/singleflight
#24 9.911 internal/bisect
#24 9.911 log/slog/internal/buffer
#24 9.911 google.golang.org/protobuf/internal/pragma
#24 9.924 internal/singleflight: /usr/local/go/pkg/tool/linux_amd64/compile: signal: illegal instruction
#24 9.925 internal/bisect: /usr/local/go/pkg/tool/linux_amd64/compile: signal: illegal instruction
```

The fix provides a separate Makefile target `docker-build` to build binaries inside 1 Docker container using the host system's architecture using Golang cross-compiling. The `release` target will expect driver binaries to be present to build a csi driver Docker image.